### PR TITLE
Make fuzzy searching more generic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ data
 .env
 
 workspace.*
+
+.idea

--- a/api/main.go
+++ b/api/main.go
@@ -103,14 +103,8 @@ func (h *handler) fuzzySearch(w http.ResponseWriter, r *http.Request) {
 	var officers []*officer
 	var err error
 
-	if firstName != "" && lastName != "" {
-		officers, err = h.db.fuzzySearchByName(strings.Trim(firstName + " " + lastName, " "))
-	} else if firstName != "" {
-		officers, err = h.db.fuzzySearchByFirstName(firstName)
-	} else if lastName != "" {
-		officers, err = h.db.fuzzySearchByLastName(lastName)
-	} else if lastName == "" {
-		officers, err = h.db.fuzzySearchByFirstName(firstName)
+	if firstName != "" || lastName != "" || badge != "" {
+		officers, err = h.db.fuzzySearchOfficer(badge, lastName, firstName)
 	} else {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintf("at least one of the following parameters must be provided: first_name, last_name, badge")))

--- a/api/main.go
+++ b/api/main.go
@@ -103,11 +103,6 @@ func (h *handler) fuzzySearch(w http.ResponseWriter, r *http.Request) {
 	var officers []*officer
 	var err error
 
-	if firstName == "" && lastName == "" && badge == "" {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(fmt.Sprintf("at least one of the following parameters must be provided: first_name, last_name, badge")))
-		return
-	}
 	if firstName != "" && lastName != "" {
 		officers, err = h.db.fuzzySearchByName(strings.Trim(firstName + " " + lastName, " "))
 	} else if firstName != "" {
@@ -117,8 +112,8 @@ func (h *handler) fuzzySearch(w http.ResponseWriter, r *http.Request) {
 	} else if badge != "" {
 		officers, err = h.db.fuzzySearchByBadge(badge)
 	} else {
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(fmt.Sprintf("error getting officer: %s", err)))
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(fmt.Sprintf("at least one of the following parameters must be provided: first_name, last_name, badge")))
 		return
 	}
 

--- a/api/main.go
+++ b/api/main.go
@@ -54,7 +54,7 @@ func (h *handler) getOfficerByBadge(badge string, w http.ResponseWriter) {
 
 	if err != nil {
 		if err.Error() == "no rows in result set" {
-			w.WriteHeader(http.StatusNotFound)
+			w.WriteHeader(http.StatusOK)
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode([]*officer{})
 			return

--- a/db/sql/4_create_functions.sql
+++ b/db/sql/4_create_functions.sql
@@ -69,3 +69,17 @@ END; $$
 LANGUAGE 'plpgsql'
 SECURITY DEFINER
 SET search_path =public, pg_temp;
+
+CREATE OR REPLACE FUNCTION fuzzy_search_officer_by_badge_p(badge_number  VARCHAR(10))
+    RETURNS SETOF officers AS $$
+BEGIN
+    RETURN QUERY SELECT *
+    FROM officers o
+    WHERE LOWER(o.badge_number) % LOWER(fuzzy_search_officer_by_badge_p.badge_number)
+    ORDER BY SIMILARITY(LOWER(o.badge_number), LOWER(fuzzy_search_officer_by_badge_p.badge_number)) DESC;
+
+    RETURN;
+END; $$
+    LANGUAGE 'plpgsql'
+    SECURITY DEFINER
+    SET search_path =public, pg_temp;

--- a/db/sql/4_create_functions.sql
+++ b/db/sql/4_create_functions.sql
@@ -28,55 +28,17 @@ LANGUAGE 'plpgsql'
 SECURITY DEFINER
 SET search_path =public, pg_temp;
 
-CREATE OR REPLACE FUNCTION fuzzy_search_officer_by_first_name_p(first_name  VARCHAR(100))
+CREATE OR REPLACE FUNCTION fuzzy_search_officer_p(badge_number  VARCHAR(10), last_name  VARCHAR(100), first_name  VARCHAR(100))
     RETURNS SETOF officers AS $$
 BEGIN
     RETURN QUERY SELECT *
-    FROM officers o
-    WHERE LOWER(o.first_name) % LOWER(fuzzy_search_officer_by_first_name_p.first_name)
-    ORDER BY SIMILARITY(LOWER(o.first_name), LOWER(fuzzy_search_officer_by_first_name_p.first_name)) DESC;
-
-    RETURN;
-END; $$
-LANGUAGE 'plpgsql'
-SECURITY DEFINER
-SET search_path =public, pg_temp;
-
-CREATE OR REPLACE FUNCTION fuzzy_search_officer_by_last_name_p(last_name  VARCHAR(100))
-    RETURNS SETOF officers AS $$
-BEGIN
-    RETURN QUERY SELECT *
-    FROM officers o
-    WHERE LOWER(o.last_name) % LOWER(fuzzy_search_officer_by_last_name_p.last_name)
-    ORDER BY SIMILARITY(LOWER(o.last_name), LOWER(fuzzy_search_officer_by_last_name_p.last_name)) DESC;
-
-    RETURN;
-END; $$
-LANGUAGE 'plpgsql'
-SECURITY DEFINER
-SET search_path =public, pg_temp;
-
-CREATE OR REPLACE FUNCTION fuzzy_search_officer_by_name_p(full_name  VARCHAR(100))
-    RETURNS SETOF officers AS $$
-BEGIN
-    RETURN QUERY SELECT *
-    FROM officers o
-    WHERE LOWER(o.first_name || ' ' || o.last_name) % LOWER(fuzzy_search_officer_by_name_p.full_name)
-    ORDER BY SIMILARITY(LOWER(o.first_name || ' ' || o.last_name), LOWER(fuzzy_search_officer_by_name_p.full_name)) DESC;
-
-    RETURN;
-END; $$
-LANGUAGE 'plpgsql'
-SECURITY DEFINER
-SET search_path =public, pg_temp;
-
-CREATE OR REPLACE FUNCTION fuzzy_search_officer_by_badge_p(badge_number  VARCHAR(10))
-    RETURNS SETOF officers AS $$
-BEGIN
-    RETURN QUERY SELECT *
-    FROM officers o
-    WHERE LOWER(o.badge_number) % LOWER(fuzzy_search_officer_by_badge_p.badge_number)
-    ORDER BY SIMILARITY(LOWER(o.badge_number), LOWER(fuzzy_search_officer_by_badge_p.badge_number)) DESC;
+                 FROM officers o
+                 WHERE LOWER(o.badge_number) % LOWER(fuzzy_search_officer_p.badge_number)
+                 OR LOWER(o.last_name) % LOWER(fuzzy_search_officer_p.last_name)
+                 OR LOWER(o.first_name) % LOWER(fuzzy_search_officer_p.first_name)
+                 ORDER BY SIMILARITY(LOWER(o.badge_number), LOWER(fuzzy_search_officer_p.badge_number)) DESC,
+                          (.5 * SIMILARITY(LOWER(o.last_name), LOWER(fuzzy_search_officer_p.last_name))) DESC,
+                          SIMILARITY(LOWER(o.first_name), LOWER(fuzzy_search_officer_p.first_name)) DESC;
 
     RETURN;
 END; $$


### PR DESCRIPTION
I named the branch bad but this evolved from enabling fuzzy badge searching into making fuzzy searching more generic in general. This PR enables the API to do fuzzy searching by either badge, last name, or first name, and weights them in that order. I'm still trying to get better at the weighting thing but I think this is pretty good for right now. I'm opening this as a draft PR so everyone can try it out and let me know what they think of the search feature.

We'll want to update the website to provide some recommendations on getting better search results after this is implemented. Specifically, it is best for badges to just put a guess in for a digit if you don't know it, e.g. if you know that a badge number is 58_3 you should put in 5803 or something similar because the fuzzy matching will perform better with that than say just 58 or 583, which which will likely not provide the desired results.