### PR TITLE
Fix init-script

### DIFF
--- a/init-script.sh
+++ b/init-script.sh
@@ -11,26 +11,26 @@ do
   esac
 done
 
-if [ $up = "true" ]
+if [ "$up" = "true" ]
 then
   docker volume rm spd-lookup_db_data
   docker-compose up --build $detached
 fi
 
-if [ $down = "true" ]
+if [ "$down" = "true" ]
 then
   docker-compose down
   docker volume rm spd-lookup_db_data
 fi
 
-if [ $restart = "true" ]
+if [ "$restart" = "true" ]
 then
   docker-compose down
   docker volume rm spd-lookup_db_data
   docker-compose up --build $detached
 fi
 
-if [ $error = "true" ]
+if [ "$error" = "true" ]
 then
   echo "error valid flags are -u, -d, -r"
 fi


### PR DESCRIPTION
Didn't realize I needed to wrap the variables in quotes to get it to stop throwing those "expected unary operator" errors.