### PR TITLE
HOTFIX: Allow the default {context}/Dockerfile file to be used

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./api
-          file: ./Dockerfile
           platforms: linux/amd64
           push: true
           tags: |
@@ -32,7 +31,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./db
-          file: ./Dockerfile
           platforms: linux/amd64
           push: true
           tags: |


### PR DESCRIPTION
The docs say that the default `Dockerfile` is `{context}/Dockerfile`, and we were explicitly defining it as elsewhere instead.

https://github.com/docker/build-push-action#customizing
