### PR TITLE
Enable local GHA testing via act repo

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        name: Set up QEMU
+        with:
+          token: ${{ github.token }}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: Set up QEMU
+        with:
+          token: ${{ github.token }}
       - uses: docker/setup-qemu-action@v1
         name: Set up Docker Buildx
       - uses: docker/setup-buildx-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            sdsa/spd-lookup-api:$RELEASE_VERSION
+            sdsa/spd-lookup-api:${{ env.RELEASE_VERSION }}
             sdsa/spd-lookup-api:latest
       - name: Build and push DB
         uses: docker/build-push-action@v2
@@ -37,5 +37,5 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            sdsa/spd-lookup-db:$RELEASE_VERSION
+            sdsa/spd-lookup-db:${{ env.RELEASE_VERSION }}
             sdsa/spd-lookup-db:latest

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ workspace.*
 .idea
 
 db/db_logs/
+
+act-secrets

--- a/act-secrets-example
+++ b/act-secrets-example
@@ -1,0 +1,3 @@
+GITHUB_TOKEN=<personal GitHub access token>
+DOCKER_HUB_USERNAME=<docker hub username>
+DOCKER_HUB_TOKEN=<docker hub token>


### PR DESCRIPTION
See the following repo for more details:
https://github.com/nektos/act

The gist is that this will enable simpler GitHub Action testing using the act repo.

I have included a new example file (and updated the .gitignore to ignore the real file) to store secrets to be used by act. This will include the GitHub personal access token, the docker hub username, and the docker hub token. These are already stored in the repo itself but must be provided for local testing of GitHub Actions. I have also updated the two actions to explicitly state the implied github.token variable to be consumed by act.