### PR TITLE
Remove historical searching by name from API

### DIFF
--- a/api/data/database.go
+++ b/api/data/database.go
@@ -33,7 +33,6 @@ type DatabaseInterface interface {
 	SeattleFuzzySearchByLastName(lastName string) ([]*SeattleOfficer, error)
 
 	SeattleGetOfficerByBadgeHistorical(badge string) ([]*SeattleOfficer, error)
-	SeattleSearchOfficerByNameHistorical(firstName, lastName string) ([]*SeattleOfficer, error)
 
 	TacomaOfficerMetadata() *DepartmentMetadata
 	TacomaSearchOfficerByName(firstName, lastName string) ([]*TacomaOfficer, error)

--- a/api/data/seattle_db.go
+++ b/api/data/seattle_db.go
@@ -94,7 +94,7 @@ func (c *Client) SeattleOfficerMetadata() *DepartmentMetadata {
 			},
 			"historical-exact": {
 				Path:        "/seattle/officer/historical",
-				QueryParams: []string{"badge", "first_name", "last_name"},
+				QueryParams: []string{"badge"},
 			},
 		},
 	}
@@ -195,38 +195,6 @@ func (c *Client) SeattleSearchOfficerByName(firstName, lastName string) ([]*Seat
 			ORDER BY 
 				o.date DESC,
 				o.full_name;
-		`,
-		firstName,
-		lastName,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	return seattleMarshalOfficerRows(rows)
-}
-
-// SeattleSearchOfficerByNameHistorical returns an officer by their first or last name. It searches the full historical
-// roster list and returns the results in descending order by roster date.
-func (c *Client) SeattleSearchOfficerByNameHistorical(firstName, lastName string) ([]*SeattleOfficer, error) {
-	rows, err := c.pool.Query(context.Background(),
-		`
-			WITH max_roster AS (SELECT MAX(date) max_date FROM seattle_officers)
-			SELECT
-				o.date,
-				o.badge,
-				o.full_name,
-				o.first_name,
-				o.middle_name,
-				o.last_name,
-				o.title,
-				o.unit,
-				o.unit_description,
-				CASE WHEN o.date = max_roster.max_date THEN TRUE ELSE FALSE END is_current
-			FROM seattle_officers o, max_roster
-			WHERE o.first_name = $1 AND o.last_name = $2
-			ORDER BY o.date DESC;
 		`,
 		firstName,
 		lastName,

--- a/api/handler/seattle.go
+++ b/api/handler/seattle.go
@@ -41,17 +41,14 @@ func (h *Handler) SeattleStrictMatch(w http.ResponseWriter, r *http.Request) {
 
 // SeattleStrictMatchHistorical is the handler function for retrieving SPD officers with a strict match
 func (h *Handler) SeattleStrictMatchHistorical(w http.ResponseWriter, r *http.Request) {
-	badge, firstName, lastName := r.URL.Query().Get("badge"), r.URL.Query().Get("first_name"), r.URL.Query().Get("last_name")
+	badge := r.URL.Query().Get("badge")
 
 	if badge != "" {
 		h.seattleGetOfficerByBadgeHistorical(badge, w)
 		return
-	} else if firstName != "" || lastName != "" {
-		h.seattleGetOfficersByNameHistorical(firstName, lastName, w)
-		return
 	} else {
 		w.WriteHeader(http.StatusBadRequest)
-		_, err := w.Write([]byte("at least one of the following parameters must be provided: badge, first_name, last_name"))
+		_, err := w.Write([]byte("at least one of the following parameters must be provided: badge"))
 		if err != nil {
 			return
 		}
@@ -119,45 +116,6 @@ func (h *Handler) seattleGetOfficersByName(firstName, lastName string, w http.Re
 
 func (h *Handler) seattleGetOfficerByBadgeHistorical(badge string, w http.ResponseWriter) {
 	officers, err := h.db.SeattleGetOfficerByBadgeHistorical(badge)
-
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		_, errWrite := w.Write([]byte(fmt.Sprintf("error getting officer: %s", err)))
-		if errWrite != nil {
-			return
-		}
-		return
-	}
-
-	sort.Slice(officers, func(a, b int) bool {
-		if officers[a].LastName == officers[b].LastName {
-			return officers[a].FirstName < officers[b].FirstName
-		}
-		return officers[a].LastName < officers[b].LastName
-	})
-
-	w.WriteHeader(http.StatusOK)
-	w.Header().Set("Content-Type", "application/json")
-	err = json.NewEncoder(w).Encode(&officers)
-	if err != nil {
-		return
-	}
-}
-
-func (h *Handler) seattleGetOfficersByNameHistorical(firstName, lastName string, w http.ResponseWriter) {
-	if firstName == "" {
-		firstName = "%"
-	} else {
-		firstName = strings.ReplaceAll(firstName, "*", "%")
-	}
-
-	if lastName == "" {
-		lastName = "%"
-	} else {
-		lastName = strings.ReplaceAll(lastName, "*", "%")
-	}
-
-	officers, err := h.db.SeattleSearchOfficerByNameHistorical(firstName, lastName)
 
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
In some discussion it was decided that we did not need to include a historical search by name API. It doesn't seem particularly useful and will result in people getting much larger return sets than they will probably be expecting. This simplifies the API and will make user workflow less convoluted.