### PR TITLE
Fix the datetime return formatting

### DIFF
--- a/api/data/portland_db.go
+++ b/api/data/portland_db.go
@@ -9,38 +9,38 @@ import (
 
 // PortlandOfficer is the object model for PPB officers
 type PortlandOfficer struct {
-	FirstName					nulls.String	`json:"first_name,omitempty"`
-	LastName					nulls.String	`json:"last_name,omitempty"`
-	Gender						nulls.String	`json:"gender,omitempty"`
-	OfficerRank					nulls.String	`json:"officer_rank,omitempty"`
-	EmployeeID					nulls.String	`json:"employee_id,omitempty"`
-	HelmetID					nulls.String	`json:"helmet_id,omitempty"`
-	HelmetIDThreeDigit			nulls.String	`json:"helmet_id_three_digit,omitempty"`
-	Salary						nulls.String	`json:"salary,omitempty"`
-	Badge						nulls.String	`json:"badge,omitempty"`
-	CopsPhotoProfileLink		nulls.String	`json:"cops_photo_profile_link,omitempty"`
-	CopsPhotoHasPhoto			nulls.String	`json:"cops_photo_has_photo,omitempty"`
-	Employed_3_12_21			nulls.String	`json:"employed_3_12_21,omitempty"`
-	Employed_12_28_20			nulls.String	`json:"employed_12_28_20,omitempty"`
-	Employed_10_01_20			nulls.String	`json:"employed_10_01_20,omitempty"`
-	Retired_6_1_20				nulls.String	`json:"retired_6_1_20,omitempty"`
-	RetiredOrCertRevoked		nulls.String	`json:"retired_or_cert_revoked,omitempty"`
-	RetiredOrCertRevokedDate	nulls.String	`json:"retired_or_cert_revoked_date,omitempty"`
-	HireYear					nulls.String	`json:"hire_year,omitempty"`
-	HireDate					nulls.String	`json:"hire_date,omitempty"`
-	StateCertDate				nulls.String	`json:"state_cert_date,omitempty"`
-	StateCertLevel				nulls.String	`json:"state_cert_level,omitempty"`
-	RRT							nulls.String	`json:"rrt,omitempty"`
-	RRT2016						nulls.String	`json:"rrt_2016,omitempty"`
-	RRT2018NiiyaEmail			nulls.String	`json:"rrt_2018_niiya_email,omitempty"`
-	RRT2018						nulls.String	`json:"rrt_2018,omitempty"`
-	RRT2019						nulls.String	`json:"rrt_2019,omitempty"`
-	RRT2020						nulls.String	`json:"rrt_2020,omitempty"`
-	SoundTruckTraining			nulls.String	`json:"sound_truck_training_2020,omitempty"`
-	InstructedForDpsst			nulls.String	`json:"instructed_for_dpsst,omitempty"`
-	InstructedForLessLethal		nulls.String	`json:"instructed_for_less_lethal,omitempty"`
-	InvolvedInOisUof			nulls.String	`json:"involved_in_ois_uof,omitempty"`
-	Notes						nulls.String	`json:"notes,omitempty"`
+	FirstName                nulls.String `json:"first_name,omitempty"`
+	LastName                 nulls.String `json:"last_name,omitempty"`
+	Gender                   nulls.String `json:"gender,omitempty"`
+	OfficerRank              nulls.String `json:"officer_rank,omitempty"`
+	EmployeeID               nulls.String `json:"employee_id,omitempty"`
+	HelmetID                 nulls.String `json:"helmet_id,omitempty"`
+	HelmetIDThreeDigit       nulls.String `json:"helmet_id_three_digit,omitempty"`
+	Salary                   nulls.String `json:"salary,omitempty"`
+	Badge                    nulls.String `json:"badge,omitempty"`
+	CopsPhotoProfileLink     nulls.String `json:"cops_photo_profile_link,omitempty"`
+	CopsPhotoHasPhoto        nulls.String `json:"cops_photo_has_photo,omitempty"`
+	Employed_3_12_21         nulls.String `json:"employed_3_12_21,omitempty"`
+	Employed_12_28_20        nulls.String `json:"employed_12_28_20,omitempty"`
+	Employed_10_01_20        nulls.String `json:"employed_10_01_20,omitempty"`
+	Retired_6_1_20           nulls.String `json:"retired_6_1_20,omitempty"`
+	RetiredOrCertRevoked     nulls.String `json:"retired_or_cert_revoked,omitempty"`
+	RetiredOrCertRevokedDate nulls.String `json:"retired_or_cert_revoked_date,omitempty"`
+	HireYear                 nulls.String `json:"hire_year,omitempty"`
+	HireDate                 nulls.String `json:"hire_date,omitempty"`
+	StateCertDate            nulls.String `json:"state_cert_date,omitempty"`
+	StateCertLevel           nulls.String `json:"state_cert_level,omitempty"`
+	RRT                      nulls.String `json:"rrt,omitempty"`
+	RRT2016                  nulls.String `json:"rrt_2016,omitempty"`
+	RRT2018NiiyaEmail        nulls.String `json:"rrt_2018_niiya_email,omitempty"`
+	RRT2018                  nulls.String `json:"rrt_2018,omitempty"`
+	RRT2019                  nulls.String `json:"rrt_2019,omitempty"`
+	RRT2020                  nulls.String `json:"rrt_2020,omitempty"`
+	SoundTruckTraining       nulls.String `json:"sound_truck_training_2020,omitempty"`
+	InstructedForDpsst       nulls.String `json:"instructed_for_dpsst,omitempty"`
+	InstructedForLessLethal  nulls.String `json:"instructed_for_less_lethal,omitempty"`
+	InvolvedInOisUof         nulls.String `json:"involved_in_ois_uof,omitempty"`
+	Notes                    nulls.String `json:"notes,omitempty"`
 }
 
 // PortlandOfficerMetadata retrieves metadata describing the PortlandOfficer struct
@@ -49,143 +49,143 @@ func (c *Client) PortlandOfficerMetadata() *DepartmentMetadata {
 		Fields: []map[string]string{
 			{
 				"FieldName": "first_name",
-				"Label": "First Name",
+				"Label":     "First Name",
 			},
 			{
 				"FieldName": "last_name",
-				"Label": "Last Name",
+				"Label":     "Last Name",
 			},
 			{
 				"FieldName": "gender",
-				"Label": "Gender",
+				"Label":     "Gender",
 			},
 			{
 				"FieldName": "officer_rank",
-				"Label": "Rank",
+				"Label":     "Rank",
 			},
 			{
 				"FieldName": "employee_id",
-				"Label": "Employee (Chest) ID",
+				"Label":     "Employee (Chest) ID",
 			},
 			{
 				"FieldName": "helmet_id",
-				"Label": "Helmet #",
+				"Label":     "Helmet #",
 			},
 			{
 				"FieldName": "helmet_id_three_digit",
-				"Label": "3-Digit Helmet #",
+				"Label":     "3-Digit Helmet #",
 			},
 			{
 				"FieldName": "salary",
-				"Label": "Fiscal Earnings 2019",
+				"Label":     "Fiscal Earnings 2019",
 			},
 			{
 				"FieldName": "badge",
-				"Label": "Badge/DPSST Number",
+				"Label":     "Badge/DPSST Number",
 			},
 			{
 				"FieldName": "cops_photo_profile_link",
-				"Label": "Cops.Photo Profile Link",
+				"Label":     "Cops.Photo Profile Link",
 			},
 			{
 				"FieldName": "cops_photo_has_photo",
-				"Label": "Pic on Cops.photo (y/n)",
+				"Label":     "Pic on Cops.photo (y/n)",
 			},
 			{
 				"FieldName": "employed_3_12_21",
-				"Label": "Employed as of 3/12/21",
+				"Label":     "Employed as of 3/12/21",
 			},
 			{
 				"FieldName": "employed_12_28_20",
-				"Label": "Employed as of 12/28/20",
+				"Label":     "Employed as of 12/28/20",
 			},
 			{
 				"FieldName": "employed_10_01_20",
-				"Label": "Employed as of 10/01/20",
+				"Label":     "Employed as of 10/01/20",
 			},
 			{
 				"FieldName": "retired_6_1_20",
-				"Label": "Retired/Resigned as of 6/1/20",
+				"Label":     "Retired/Resigned as of 6/1/20",
 			},
 			{
 				"FieldName": "retired_or_cert_revoked",
-				"Label": "Retired/Resigned as of 6/1/20 OR Cert Revoked (ever)",
+				"Label":     "Retired/Resigned as of 6/1/20 OR Cert Revoked (ever)",
 			},
 			{
 				"FieldName": "retired_or_cert_revoked_date",
-				"Label": "Date of Cert Revoke",
+				"Label":     "Date of Cert Revoke",
 			},
 			{
 				"FieldName": "hire_year",
-				"Label": "Hire Year",
+				"Label":     "Hire Year",
 			},
 			{
 				"FieldName": "hire_date",
-				"Label": "Hire Date",
+				"Label":     "Hire Date",
 			},
 			{
 				"FieldName": "state_cert_date",
-				"Label": "State Certification Date",
+				"Label":     "State Certification Date",
 			},
 			{
 				"FieldName": "state_cert_level",
-				"Label": "State Certification Level",
+				"Label":     "State Certification Level",
 			},
 			{
 				"FieldName": "rrt",
-				"Label": "RRT (Rapid Response Team) Member",
+				"Label":     "RRT (Rapid Response Team) Member",
 			},
 			{
 				"FieldName": "rrt_2016",
-				"Label": "RRT member as of 2016 via 2017 PPB AR",
+				"Label":     "RRT member as of 2016 via 2017 PPB AR",
 			},
 			{
 				"FieldName": "rrt_2018_niiya_email",
-				"Label": "RRT member as of 2018 via Niiya Email",
+				"Label":     "RRT member as of 2018 via Niiya Email",
 			},
 			{
 				"FieldName": "rrt_2018",
-				"Label": "RRT Specific Training 2018",
+				"Label":     "RRT Specific Training 2018",
 			},
 			{
 				"FieldName": "rrt_2019",
-				"Label": "RRT Specific Training 2019",
+				"Label":     "RRT Specific Training 2019",
 			},
 			{
 				"FieldName": "rrt_2020",
-				"Label": "RRT Specific Training 2020",
+				"Label":     "RRT Specific Training 2020",
 			},
 			{
 				"FieldName": "sound_truck_training_2020",
-				"Label": "Sound Truck Training 2020",
+				"Label":     "Sound Truck Training 2020",
 			},
 			{
 				"FieldName": "instructed_for_dpsst",
-				"Label": "Has Instructed Course for DPSST 2017+",
+				"Label":     "Has Instructed Course for DPSST 2017+",
 			},
 			{
 				"FieldName": "instructed_for_less_lethal",
-				"Label": "Instructor for Less Lethal/Chemical Weapons Courses",
+				"Label":     "Instructor for Less Lethal/Chemical Weapons Courses",
 			},
 			{
 				"FieldName": "involved_in_ois_uof",
-				"Label": "Has Been Involved in OIS/Significant UoF Incident",
+				"Label":     "Has Been Involved in OIS/Significant UoF Incident",
 			},
 			{
 				"FieldName": "notes",
-				"Label": "Notes",
+				"Label":     "Notes",
 			},
 		},
 		LastAvailableRosterDate: "2021-03-12",
-		Name:					"Portland PB",
-		ID:					  "ppb",
+		Name:                    "Portland PB",
+		ID:                      "ppb",
 		SearchRoutes: map[string]*SearchRouteMetadata{
 			"exact": {
-				Path:		"/portland/officer",
+				Path:        "/portland/officer",
 				QueryParams: []string{"badge", "first_name", "last_name", "employee_id", "helmet_id", "helmet_id_three_digit"},
 			},
 			"fuzzy": {
-				Path:		"/portland/officer/search",
+				Path:        "/portland/officer/search",
 				QueryParams: []string{"first_name", "last_name"},
 			},
 		},

--- a/api/data/seattle_db.go
+++ b/api/data/seattle_db.go
@@ -11,16 +11,31 @@ import (
 
 // SeattleOfficer is the object model for SPD officers
 type SeattleOfficer struct {
-	Date            time.Time    `json:"date,omitempty"`
-	Badge           string       `json:"badge,omitempty"`
-	FullName        string       `json:"full_name,omitempty"`
-	Title           string       `json:"title,omitempty"`
-	Unit            string       `json:"unit,omitempty"`
-	UnitDescription nulls.String `json:"unit_description,omitempty"`
-	FirstName       string       `json:"first_name,omitempty"`
-	MiddleName      nulls.String `json:"middle_name,omitempty"`
-	LastName        string       `json:"last_name,omitempty"`
-	Current         bool         `json:"is_current"`
+	Date            string `json:"date,omitempty"`
+	Badge           string `json:"badge,omitempty"`
+	FullName        string `json:"full_name,omitempty"`
+	Title           string `json:"title,omitempty"`
+	Unit            string `json:"unit,omitempty"`
+	UnitDescription string `json:"unit_description,omitempty"`
+	FirstName       string `json:"first_name,omitempty"`
+	MiddleName      string `json:"middle_name,omitempty"`
+	LastName        string `json:"last_name,omitempty"`
+	Current         bool   `json:"is_current"`
+}
+
+// seattleOfficer is an internal intermediary between the returned SQL rows data
+// and the actual JSON return itself.
+type seattleOfficer struct {
+	Date            time.Time
+	Badge           nulls.String
+	FullName        nulls.String
+	Title           nulls.String
+	Unit            nulls.String
+	UnitDescription nulls.String
+	FirstName       nulls.String
+	MiddleName      nulls.String
+	LastName        nulls.String
+	Current         bool
 }
 
 // SeattleOfficerMetadata retrieves metadata describing the SeattleOfficer struct
@@ -335,7 +350,7 @@ func (c *Client) SeattleFuzzySearchByLastName(lastName string) ([]*SeattleOffice
 func seattleMarshalOfficerRows(rows pgx.Rows) ([]*SeattleOfficer, error) {
 	officers := []*SeattleOfficer{}
 	for rows.Next() {
-		ofc := SeattleOfficer{}
+		ofc := seattleOfficer{}
 		err := rows.Scan(
 			&ofc.Date,
 			&ofc.Badge,
@@ -352,7 +367,21 @@ func seattleMarshalOfficerRows(rows pgx.Rows) ([]*SeattleOfficer, error) {
 		if err != nil {
 			return nil, err
 		}
-		officers = append(officers, &ofc)
+
+		returnOfficer := SeattleOfficer{
+			ofc.Date.Format("2006-01-02"),
+			ofc.Badge.String,
+			ofc.FullName.String,
+			ofc.Title.String,
+			ofc.Unit.String,
+			ofc.UnitDescription.String,
+			ofc.FirstName.String,
+			ofc.MiddleName.String,
+			ofc.LastName.String,
+			ofc.Current,
+		}
+
+		officers = append(officers, &returnOfficer)
 	}
 	return officers, nil
 }

--- a/api/data/tacoma_db.go
+++ b/api/data/tacoma_db.go
@@ -22,12 +22,12 @@ type TacomaOfficer struct {
 // tacomaOfficer is an internal intermediary between the returned SQL rows data
 // and the actual JSON return itself.
 type tacomaOfficer struct {
-	Date       time.Time    `json:"date,omitempty"`
-	FirstName  nulls.String `json:"first_name,omitempty"`
-	LastName   nulls.String `json:"last_name,omitempty"`
-	Title      nulls.String `json:"title,omitempty"`
-	Department nulls.String `json:"department,omitempty"`
-	Salary     nulls.String `json:"salary,omitempty"`
+	Date       time.Time
+	FirstName  nulls.String
+	LastName   nulls.String
+	Title      nulls.String
+	Department nulls.String
+	Salary     nulls.String
 }
 
 // TacomaOfficerMetadata retrieves metadata describing the TacomaOfficer struct

--- a/api/data/tacoma_db.go
+++ b/api/data/tacoma_db.go
@@ -11,11 +11,11 @@ import (
 
 // TacomaOfficer is the object model for Tacoma PD officers
 type TacomaOfficer struct {
-	Date       string    `json:"date,omitempty"`
-	FirstName  string       `json:"first_name,omitempty"`
-	LastName   string       `json:"last_name,omitempty"`
-	Title      string       `json:"title,omitempty"`
-	Department string       `json:"department,omitempty"`
+	Date       string `json:"date,omitempty"`
+	FirstName  string `json:"first_name,omitempty"`
+	LastName   string `json:"last_name,omitempty"`
+	Title      string `json:"title,omitempty"`
+	Department string `json:"department,omitempty"`
 	Salary     string `json:"salary,omitempty"`
 }
 
@@ -23,10 +23,10 @@ type TacomaOfficer struct {
 // and the actual JSON return itself.
 type tacomaOfficer struct {
 	Date       time.Time    `json:"date,omitempty"`
-	FirstName  nulls.String       `json:"first_name,omitempty"`
-	LastName   nulls.String       `json:"last_name,omitempty"`
-	Title      nulls.String       `json:"title,omitempty"`
-	Department nulls.String       `json:"department,omitempty"`
+	FirstName  nulls.String `json:"first_name,omitempty"`
+	LastName   nulls.String `json:"last_name,omitempty"`
+	Title      nulls.String `json:"title,omitempty"`
+	Department nulls.String `json:"department,omitempty"`
 	Salary     nulls.String `json:"salary,omitempty"`
 }
 

--- a/api/data/tacoma_db.go
+++ b/api/data/tacoma_db.go
@@ -11,11 +11,22 @@ import (
 
 // TacomaOfficer is the object model for Tacoma PD officers
 type TacomaOfficer struct {
-	Date       time.Time    `json:"date,omitempty"`
+	Date       string    `json:"date,omitempty"`
 	FirstName  string       `json:"first_name,omitempty"`
 	LastName   string       `json:"last_name,omitempty"`
 	Title      string       `json:"title,omitempty"`
 	Department string       `json:"department,omitempty"`
+	Salary     string `json:"salary,omitempty"`
+}
+
+// tacomaOfficer is an internal intermediary between the returned SQL rows data
+// and the actual JSON return itself.
+type tacomaOfficer struct {
+	Date       time.Time    `json:"date,omitempty"`
+	FirstName  nulls.String       `json:"first_name,omitempty"`
+	LastName   nulls.String       `json:"last_name,omitempty"`
+	Title      nulls.String       `json:"title,omitempty"`
+	Department nulls.String       `json:"department,omitempty"`
 	Salary     nulls.String `json:"salary,omitempty"`
 }
 
@@ -168,7 +179,7 @@ func (c *Client) TacomaFuzzySearchByLastName(lastName string) ([]*TacomaOfficer,
 func marshalTacomaOfficerRows(rows pgx.Rows) ([]*TacomaOfficer, error) {
 	officers := []*TacomaOfficer{}
 	for rows.Next() {
-		ofc := TacomaOfficer{}
+		ofc := tacomaOfficer{}
 		err := rows.Scan(
 			&ofc.Date,
 			&ofc.FirstName,
@@ -181,7 +192,16 @@ func marshalTacomaOfficerRows(rows pgx.Rows) ([]*TacomaOfficer, error) {
 		if err != nil {
 			return nil, err
 		}
-		officers = append(officers, &ofc)
+
+		returnOfficer := TacomaOfficer{
+			ofc.Date.Format("2006-01-02"),
+			ofc.FirstName.String,
+			ofc.LastName.String,
+			ofc.Title.String,
+			ofc.Department.String,
+			ofc.Salary.String,
+		}
+		officers = append(officers, &returnOfficer)
 	}
 	return officers, nil
 }

--- a/api/handler/fixtures_test.go
+++ b/api/handler/fixtures_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"spd-lookup/api/data"
-	"time"
 
 	"github.com/gorilla/mux"
 )
@@ -28,7 +27,7 @@ type MockDatabase struct {
 	data.DatabaseInterface
 }
 
-var mayday, _ = time.Parse("2006-01-02", "1889-05-01")
+var mayday = "1889-05-01"
 
 func (m *MockDatabase) SeattleOfficerMetadata() *data.DepartmentMetadata {
 	return &data.DepartmentMetadata{

--- a/api/handler/portland.go
+++ b/api/handler/portland.go
@@ -22,23 +22,23 @@ func (h *Handler) PortlandOfficerMetadata(w http.ResponseWriter, r *http.Request
 
 // PortlandStrictMatch is the handler function for retrieving SPD officers with a strict match
 func (h *Handler) PortlandStrictMatch(w http.ResponseWriter, r *http.Request) {
-    badge := r.URL.Query().Get("badge")
-    firstName := r.URL.Query().Get("first_name")
-    lastName := r.URL.Query().Get("last_name")
-    employeeId := r.URL.Query().Get("employee_id")
-    helmetId := r.URL.Query().Get("helmet_id")
-    helmetIdThreeDigit := r.URL.Query().Get("helmet_id_three_digit")
+	badge := r.URL.Query().Get("badge")
+	firstName := r.URL.Query().Get("first_name")
+	lastName := r.URL.Query().Get("last_name")
+	employeeId := r.URL.Query().Get("employee_id")
+	helmetId := r.URL.Query().Get("helmet_id")
+	helmetIdThreeDigit := r.URL.Query().Get("helmet_id_three_digit")
 
 	if badge != "" {
 		h.portlandGetOfficersByBadge(badge, w)
 		return
-    } else if employeeId != "" {
+	} else if employeeId != "" {
 		h.portlandGetOfficersByEmployeeId(employeeId, w)
 		return
-    } else if helmetId != "" {
+	} else if helmetId != "" {
 		h.portlandGetOfficersByHelmetId(helmetId, w)
 		return
-    } else if helmetIdThreeDigit != "" {
+	} else if helmetIdThreeDigit != "" {
 		h.portlandGetOfficersByHelmetIdThreeDigit(helmetIdThreeDigit, w)
 		return
 	} else if firstName != "" || lastName != "" {
@@ -110,7 +110,6 @@ func (h *Handler) portlandGetOfficersByEmployeeId(employeeId string, w http.Resp
 		return
 	}
 
-
 	sort.Slice(officers, func(a, b int) bool {
 		if officers[a].LastName == officers[b].LastName {
 			return officers[a].FirstName.String < officers[b].FirstName.String
@@ -147,7 +146,6 @@ func (h *Handler) portlandGetOfficersByHelmetId(helmetId string, w http.Response
 		return
 	}
 
-
 	sort.Slice(officers, func(a, b int) bool {
 		if officers[a].LastName == officers[b].LastName {
 			return officers[a].FirstName.String < officers[b].FirstName.String
@@ -183,7 +181,6 @@ func (h *Handler) portlandGetOfficersByHelmetIdThreeDigit(helmetIdThreeDigit str
 		}
 		return
 	}
-
 
 	sort.Slice(officers, func(a, b int) bool {
 		if officers[a].LastName == officers[b].LastName {

--- a/api/handler/seattle.go
+++ b/api/handler/seattle.go
@@ -126,13 +126,6 @@ func (h *Handler) seattleGetOfficerByBadgeHistorical(badge string, w http.Respon
 		return
 	}
 
-	sort.Slice(officers, func(a, b int) bool {
-		if officers[a].Date == officers[b].Date {
-			return officers[a].Date > officers[b].Date
-		}
-		return officers[a].Date > officers[b].Date
-	})
-
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
 	err = json.NewEncoder(w).Encode(&officers)

--- a/api/handler/seattle.go
+++ b/api/handler/seattle.go
@@ -127,10 +127,10 @@ func (h *Handler) seattleGetOfficerByBadgeHistorical(badge string, w http.Respon
 	}
 
 	sort.Slice(officers, func(a, b int) bool {
-		if officers[a].LastName == officers[b].LastName {
-			return officers[a].FirstName < officers[b].FirstName
+		if officers[a].Date == officers[b].Date {
+			return officers[a].Date > officers[b].Date
 		}
-		return officers[a].LastName < officers[b].LastName
+		return officers[a].Date > officers[b].Date
 	})
 
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
This pull request resolves the issue where the date return includes time which is not really desirable. This update uses the time.Format method to return the date in a normal ISO format that is easier to read and understand.