### PR TITLE
Fix roster source date

### DIFF
--- a/api/data/tacoma_db.go
+++ b/api/data/tacoma_db.go
@@ -2,7 +2,6 @@ package data
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/gobuffalo/nulls"

--- a/api/data/tacoma_db.go
+++ b/api/data/tacoma_db.go
@@ -32,18 +32,6 @@ type tacomaOfficer struct {
 
 // TacomaOfficerMetadata retrieves metadata describing the TacomaOfficer struct
 func (c *Client) TacomaOfficerMetadata() *DepartmentMetadata {
-	var date time.Time
-	err := c.pool.QueryRow(context.Background(),
-		`
-			SELECT max(date) as date
-			FROM tacoma_officers;
-		`).Scan(&date)
-
-	if err != nil {
-		fmt.Printf("DB Client Error: %s", err)
-		return &DepartmentMetadata{}
-	}
-
 	return &DepartmentMetadata{
 		Fields: []map[string]string{
 			{
@@ -64,10 +52,10 @@ func (c *Client) TacomaOfficerMetadata() *DepartmentMetadata {
 			},
 			{
 				"FieldName": "salary",
-				"Label":     "Salary",
+				"Label":     "Salary 2019",
 			},
 		},
-		LastAvailableRosterDate: date.Format("2006-01-02"),
+		LastAvailableRosterDate: "2019",
 		Name:                    "Tacoma PD",
 		ID:                      "tpd",
 		SearchRoutes: map[string]*SearchRouteMetadata{


### PR DESCRIPTION
The correct date for the roster source from Tacoma was for any officer who worked for the Tacoma Police Department in the year 2019, along with the salary information that was provided. Somewhere along the line the CSV was updated to include the date the roster was added to the site, rather than the actual source date for the roster.

Because this roster data is not from a particular day, I've updated the DepartmentMetadata object to just return a simple String of 2019 instead of converting a date and using the erroneous date in the CSV column. This will be further addressed in another PR to handle the Tacoma PD data better.